### PR TITLE
back end for tag creation

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -20,6 +20,7 @@ from views import (
     delete_post,
     get_comments_by_post_id,
     create_comment,
+    create_tag,
 )
 
 
@@ -131,6 +132,15 @@ class JSONServer(HandleRequests):
             request_body = json.loads(request_body)
 
             response_body = create_post(request_body)
+            return self.response(response_body, status.HTTP_201_SUCCESS_CREATED.value)
+        
+        elif url["requested_resource"] == "tags":
+            # Get the request body JSON for the new data
+            content_len = int(self.headers.get("content-length", 0))
+            request_body = self.rfile.read(content_len)
+            request_body = json.loads(request_body)
+
+            response_body = create_tag(request_body)
             return self.response(response_body, status.HTTP_201_SUCCESS_CREATED.value)
 
         elif url["requested_resource"] == "Comments":

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -19,3 +19,7 @@ from .posts import (
 
 from .comments import get_comments_by_post_id
 from .comment import create_comment
+
+from .tags import (
+    create_tag,
+)

--- a/views/tags.py
+++ b/views/tags.py
@@ -1,0 +1,23 @@
+import sqlite3
+import json
+
+
+def create_tag(tag):
+    """Creates a new tag in the database"""
+
+    with sqlite3.connect("./db.sqlite3") as conn:
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+            INSERT INTO Tags (label)
+            VALUES (?)
+            """,
+            (
+                tag["label"],
+            ),  # Ensure "tag" is a dictionary and "label" is a valid key
+        )
+
+        id = db_cursor.lastrowid
+
+        return json.dumps({"id": id, "label": tag["label"]})


### PR DESCRIPTION
# Description

This PR holds the code for the backend of the create tag feature.

Fixes # (issue)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [x] New feature

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors

# How Should I Test This?

Because the "/tags" view is still being worked on you will need to use postman to simulate the client side

- [ ] Step 1 Open post man and select POST from the drop down menu
- [ ] Step 2 Select "body" and then "Raw" then write in the text field {"label":"funny"}
- [ ] Step 3 Press the send button and you should find the newly created tag in the database file
